### PR TITLE
Use com_google_protobuf as repo name for protobuf

### DIFF
--- a/java/BUILD.bazel
+++ b/java/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@protobuf//bazel:java_proto_library.bzl", "java_proto_library")
+load("@com_google_protobuf//bazel:java_proto_library.bzl", "java_proto_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/java/MODULE.bazel
+++ b/java/MODULE.bazel
@@ -5,7 +5,7 @@ module(
 
 bazel_dep(name = "bazel_worker_api", version = "0.0.1")
 bazel_dep(name = "rules_jvm_external", version = "6.2")
-bazel_dep(name = "protobuf", version = "27.2")
+bazel_dep(name = "protobuf", version = "27.2", repo_name = "com_google_protobuf")
 bazel_dep(name = "rules_java", version = "7.12.2")
 
 maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")

--- a/proto/BUILD.bazel
+++ b/proto/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@protobuf//bazel:proto_library.bzl", "proto_library")
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/proto/MODULE.bazel
+++ b/proto/MODULE.bazel
@@ -3,4 +3,4 @@ module(
     version = "0",
 )
 
-bazel_dep(name = "protobuf", version = "27.2")
+bazel_dep(name = "protobuf", version = "27.2", repo_name = "com_google_protobuf")


### PR DESCRIPTION
To keep compatibility with WORKSPACE use cases.