### PR TITLE
Set up Github Actions release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,5 @@ jobs:
     uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v7.2.2
     with:
       release_files: bazel-worker-api-*.tar.gz
-      bazel_test_command: "bazel build @bazel_worker_java//... @bazel_worker_api//..."
       tag_name: ${{ inputs.tag_name || github.ref_name }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+# Cut a release whenever a new tag is pushed to the repo.
+# You should use an annotated tag, like `git tag -a v1.2.3`
+# and put the release notes into the commit message for the tag.
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  attestations: write
+  id-token: write
+  contents: write
+
+jobs:
+  release:
+    uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v7.2.2
+    with:
+      release_files: bazel-worker-api-*.tar.gz
+      bazel_test_command: "bazel build @bazel_worker_java//... @bazel_worker_api//..."
+      tag_name: ${{ inputs.tag_name || github.ref_name }}
+  publish:
+    needs: release
+    uses: ./.github/workflows/publish.yml
+    with:
+      tag_name: ${{ inputs.tag_name || github.ref_name }}
+    secrets:
+      publish_token: ${{ secrets.publish_token || secrets.BCR_PUBLISH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,4 @@ jobs:
       release_files: bazel-worker-api-*.tar.gz
       bazel_test_command: "bazel build @bazel_worker_java//... @bazel_worker_api//..."
       tag_name: ${{ inputs.tag_name || github.ref_name }}
-  publish:
-    needs: release
-    uses: ./.github/workflows/publish.yml
-    with:
-      tag_name: ${{ inputs.tag_name || github.ref_name }}
-    secrets:
-      publish_token: ${{ secrets.publish_token || secrets.BCR_PUBLISH_TOKEN }}
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,5 +18,6 @@ jobs:
     uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v7.2.2
     with:
       release_files: bazel-worker-api-*.tar.gz
+      bazel_test_command: "bazel build @bazel_worker_java//... @bazel_worker_api//..."
       tag_name: ${{ inputs.tag_name || github.ref_name }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,6 @@ jobs:
     uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v7.2.2
     with:
       release_files: bazel-worker-api-*.tar.gz
-      bazel_test_command: "bazel build @bazel_worker_java//... @bazel_worker_api//..."
+      bazel_test_command: "cd java && bazel test //... && cd ../proto && bazel build //..."
       tag_name: ${{ inputs.tag_name || github.ref_name }}
 

--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Copyright 2026 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#		http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit -o nounset -o pipefail
+
+# Set by GH actions, see
+# https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
+TAG=${GITHUB_REF_NAME}
+# The prefix is chosen to match what GitHub generates for source archives
+# This guarantees that users can easily switch from a released artifact to a source archive
+# with minimal differences in their code (e.g. strip_prefix remains the same)
+PREFIX="bazel-worker-api-${TAG:1}"
+ARCHIVE="bazel-worker-api-$TAG.tar.gz"
+
+# NB: configuration for 'git archive' is in /.gitattributes
+git archive --format=tar --prefix=${PREFIX}/ ${TAG} | gzip > $ARCHIVE
+SHA=$(shasum -a 256 $ARCHIVE | awk '{print $1}')
+
+cat << EOF
+## Using Bzlmod with Bazel 6 or greater
+
+1. (Bazel 6 only) Enable with \`common --enable_bzlmod\` in \`.bazelrc\`.
+2. Add to your \`MODULE.bazel\` file:
+
+\`\`\`starlark
+# See examples/basicapp/MODULE.bazel.
+bazel_dep(name = "bazel_worker_api", version = "${TAG:1}")
+bazel_dep(name = "bazel_worker_java", version = "${TAG:1}")
+\`\`\`
+
+## Using WORKSPACE
+
+Paste this snippet into your \`WORKSPACE.bazel\` file:
+
+\`\`\`starlark
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+http_archive(
+    name = "bazel_worker_api",
+    sha256 = "${SHA}",
+    strip_prefix = "${PREFIX}/proto",
+    url = "https://github.com/bazelbuild/bazel-worker-api/releases/download/${TAG}/${ARCHIVE}",
+)
+http_archive(
+    name = "bazel_worker_java",
+    sha256 = "${SHA}",
+    strip_prefix = "${PREFIX}/java",
+    url = "https://github.com/bazelbuild/bazel-worker-api/releases/download/${TAG}/${ARCHIVE}",
+)
+\`\`\`
+EOF


### PR DESCRIPTION
Automatically creates a release archive every time a new tag is pushed.

Example release (in my fork): https://github.com/ted-xie/bazel-worker-api/releases/tag/v0.0.999d

From this GHA run: https://github.com/ted-xie/bazel-worker-api/actions/runs/26844448792/job/79160048830